### PR TITLE
Add ds_arm7_ram.ld and ds_arm7_ram.specs

### DIFF
--- a/dkarm-eabi/crtls/ds_arm7_ram.ld
+++ b/dkarm-eabi/crtls/ds_arm7_ram.ld
@@ -1,0 +1,176 @@
+OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+ENTRY(_start)
+
+MEMORY {
+	rom	: ORIGIN = 0x08000000, LENGTH = 32M
+  ram	: ORIGIN = 0x2380000, LENGTH = 32K
+	iwram	: ORIGIN = 0x037f8000, LENGTH = 96K	
+}
+
+__iwram_start	=	ORIGIN(iwram);
+__iwram_top	=	ORIGIN(iwram)+ LENGTH(iwram);
+
+__sp_irq	=	__iwram_top - 0x100;
+__sp_svc	=	__sp_irq - 0x100;
+__sp_usr	=	__sp_svc - 0x100;
+
+__irq_flags	=	0x04000000 - 8;
+__irq_flagsaux	=	0x04000000 - 0x40;
+__irq_vector	=	0x04000000 - 4;
+
+SECTIONS
+{
+	.init	:
+	{
+		__text_start = . ;
+		KEEP (*(.init))
+		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
+		} >ram = 0xff
+	.plt : { *(.plt) } >ram = 0xff
+
+	.text :   /* ALIGN (4): */
+	{
+		*(.text .stub .text.* .gnu.linkonce.t.*)
+		KEEP (*(.text.*personality*))
+		/* .gnu.warning sections are handled specially by elf32.em.  */
+		*(.gnu.warning)
+		*(.glue_7t) *(.glue_7) *(.vfp11_veneer)
+		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
+	} >ram = 0xff
+
+	.fini           :
+	{
+		KEEP (*(.fini))
+	} >ram =0xff
+
+	__text_end = . ;
+
+	.rodata :
+	{
+		*(.rodata)
+		*all.rodata*(*)
+		*(.roda)
+		*(.rodata.*)
+		*(.gnu.linkonce.r*)
+		SORT(CONSTRUCTORS)
+		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+	} >ram = 0xff
+
+	.ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >ram
+	__exidx_start = .;
+	.ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } >ram
+	__exidx_end = .;
+
+/* Ensure the __preinit_array_start label is properly aligned.  We
+   could instead move the label definition inside the section, but
+   the linker would then create the section even if it turns out to
+   be empty, which isn't pretty.  */
+	. = ALIGN(32 / 8);
+	PROVIDE (__preinit_array_start = .);
+	.preinit_array     : { KEEP (*(.preinit_array)) } >ram = 0xff
+	PROVIDE (__preinit_array_end = .);
+	PROVIDE (__init_array_start = .);
+	.init_array     : { KEEP (*(.init_array)) } >ram = 0xff
+	PROVIDE (__init_array_end = .);
+	PROVIDE (__fini_array_start = .);
+	.fini_array     : { KEEP (*(.fini_array)) } >ram = 0xff
+	PROVIDE (__fini_array_end = .);
+
+	.ctors :
+	{
+	/* gcc uses crtbegin.o to find the start of the constructors, so
+		we make sure it is first.  Because this is a wildcard, it
+		doesn't matter if the user does not actually link against
+		crtbegin.o; the linker won't look for a file to match a
+		wildcard.  The wildcard also means that it doesn't matter which
+		directory crtbegin.o is in.  */
+		KEEP (*crtbegin.o(.ctors))
+		KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+		KEEP (*(SORT(.ctors.*)))
+		KEEP (*(.ctors))
+		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+	} >ram = 0xff
+
+	.dtors :
+	{
+		KEEP (*crtbegin.o(.dtors))
+		KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+		KEEP (*(SORT(.dtors.*)))
+		KEEP (*(.dtors))
+		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+	} >ram = 0xff
+
+	.eh_frame :
+	{
+		KEEP (*(.eh_frame))
+		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+	} >ram = 0xff
+
+	.gcc_except_table :
+	{
+		*(.gcc_except_table)
+		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+	} >ram = 0xff
+	.jcr            : { KEEP (*(.jcr)) } >ram = 0
+	.got            : { *(.got.plt) *(.got) } >ram = 0
+
+	.data ALIGN(4) : 	{
+		__data_start = ABSOLUTE(.);
+		*(.data)
+		*(.data.*)
+		*(.gnu.linkonce.d*)
+		CONSTRUCTORS
+		. = ALIGN(4);
+		__data_end = ABSOLUTE(.) ;
+	} >ram = 0xff
+
+	.bss ALIGN(4) :
+	{
+		__bss_start = ABSOLUTE(.);
+		__bss_start__ = ABSOLUTE(.);
+		*(.dynbss)
+		*(.gnu.linkonce.b*)
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+		__bss_end__ = ABSOLUTE(.);
+		__end__ = ABSOLUTE(.);
+	} >ram
+
+	/* Stabs debugging sections.  */
+	.stab 0 : { *(.stab) }
+	.stabstr 0 : { *(.stabstr) }
+	.stab.excl 0 : { *(.stab.excl) }
+	.stab.exclstr 0 : { *(.stab.exclstr) }
+	.stab.index 0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment 0 : { *(.comment) }
+	/*	DWARF debug sections.
+		Symbols in the DWARF debugging sections are relative to the beginning
+		of the section so we begin them at 0.  */
+	/* DWARF 1 */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2 */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2 */
+	.debug_info     0 : { *(.debug_info) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	.stack 0x80000 : { _stack = .; *(.stack) }
+	/* These must appear regardless of  .  */
+}

--- a/dkarm-eabi/crtls/ds_arm7_ram.ld
+++ b/dkarm-eabi/crtls/ds_arm7_ram.ld
@@ -4,7 +4,7 @@ ENTRY(_start)
 
 MEMORY {
 	rom	: ORIGIN = 0x08000000, LENGTH = 32M
-  ram	: ORIGIN = 0x2380000, LENGTH = 32K
+  ram	: ORIGIN = 0x2380000, LENGTH = 64K
 	iwram	: ORIGIN = 0x037f8000, LENGTH = 96K	
 }
 

--- a/dkarm-eabi/crtls/ds_arm7_ram.specs
+++ b/dkarm-eabi/crtls/ds_arm7_ram.specs
@@ -1,0 +1,8 @@
+%rename link                old_link
+
+*link:
+%(old_link) -T ds_arm7_ram.ld%s --gc-sections
+
+*startfile:
+ds_arm7_crt0%O%s crti%O%s crtbegin%O%s
+


### PR DESCRIPTION
added specs and ld file to optionnaly compile arm7 binaries with main ram location, this is currently mandatory in order to run an nds homebrew as a dsiware .cia on 3ds.

I choosed the same address (0x2380000) as most retail cart for the main ram region.
