### PR TITLE
allow multiple jobs at once for multi-processor

### DIFF
--- a/build-devkit.sh
+++ b/build-devkit.sh
@@ -144,6 +144,13 @@ fi
 echo use $MAKE as make
 export MAKE
 
+if NPROC=$(nproc); then
+	MAKEFLAGS="$MAKEFLAGS -j$(($NPROC * 2))"
+fi
+
+echo use \'$MAKEFLAGS\' as MAKEFLAGS
+export MAKEFLAGS
+
 #---------------------------------------------------------------------------------
 # Add installed devkit to the path, adjusting path on minsys
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
Allow twice as many jobs as the processors the host has.
It will make the build much faster.
