### PR TITLE
Added contrib/download_prerequisites step to GCC builds.

### DIFF
--- a/dka64/scripts/build-gcc.sh
+++ b/dka64/scripts/build-gcc.sh
@@ -39,6 +39,9 @@ cd $target/gcc
 
 if [ ! -f configured-gcc ]
 then
+	pushd ../../gcc-$GCC_VER
+		./contrib/download_prerequisites
+		popd
 	CFLAGS="$cflags" \
 	CXXFLAGS="$cflags" \
 	LDFLAGS="$ldflags" \

--- a/dkarm-eabi/scripts/build-gcc.sh
+++ b/dkarm-eabi/scripts/build-gcc.sh
@@ -39,6 +39,9 @@ cd $target/gcc
 
 if [ ! -f configured-gcc ]
 then
+	pushd ../../gcc-$GCC_VER
+		./contrib/download_prerequisites
+		popd
 	CFLAGS="$cflags" \
 	CXXFLAGS="$cflags" \
 	LDFLAGS="$ldflags" \

--- a/dkppc/scripts/build-gcc.sh
+++ b/dkppc/scripts/build-gcc.sh
@@ -75,6 +75,9 @@ cd $target/gcc
 
 if [ ! -f configured-gcc ]
 then
+	pushd ../../gcc-$GCC_VER
+		./contrib/download_prerequisites
+		popd
 	CFLAGS="$cflags" \
 	CXXFLAGS="$cflags" \
 	LDFLAGS="$ldflags" \


### PR DESCRIPTION
Added contrib/download_prerequisites step to GCC builds to download gmp, mpfr, mpc and isl automatically. This can reduce potential issues with system-provided libs such as not being present or an incompatible/older version.