### PR TITLE
Improve robustness of some newlib functions

### DIFF
--- a/dkppc/patches/newlib-3.3.0.patch
+++ b/dkppc/patches/newlib-3.3.0.patch
@@ -6381,7 +6381,7 @@ index 000000000..eeeab1a7b
 +
 +	ret = -1;
 +
-+	if ( sourceDev == destDev) {
++	if ( sourceDev == destDev && destDev != -1 ) {
 +		if (devoptab_list[destDev]->link_r) {
 +			r->deviceData = devoptab_list[destDev]->deviceData;
 +			ret = devoptab_list[destDev]->link_r( r, existing, new);
@@ -6507,11 +6507,15 @@ index 000000000..b4fcbd3d7
 +	int dev = FindDevice(path);
 +	ret = -1;
 +
-+	if (devoptab_list[dev]->mkdir_r) {
-+		r->deviceData = devoptab_list[dev]->deviceData;
-+		ret = devoptab_list[dev]->mkdir_r(r, path, mode);
++	if (dev!=-1) {
++		if (devoptab_list[dev]->mkdir_r) {
++			r->deviceData = devoptab_list[dev]->deviceData;
++			ret = devoptab_list[dev]->mkdir_r(r, path, mode);
++		} else {
++			r->_errno = ENOSYS;
++		}
 +	} else {
-+		r->_errno = ENOSYS;
++		r->_errno = ENODEV;
 +	}
 +
 +	return ret;
@@ -6665,7 +6669,7 @@ index 000000000..1d7b7e8e7
 +
 +	ret = -1;
 +
-+	if ( sourceDev == destDev) {
++	if ( sourceDev == destDev && destDev != -1) {
 +		if (devoptab_list[destDev]->rename_r) {
 +			r->deviceData = devoptab_list[destDev]->deviceData;
 +			ret = devoptab_list[destDev]->rename_r( r, existing, newName);


### PR DESCRIPTION
Crash can occur if those functions are called with a relative path before defaultDevice has been correctly initialized or with an unmounted device path.

It has been observed in Wii homebrew loaded with Wiiflow that crashes with a DSI exception when mkdir function is called because fatInitDefault() function failed to set defaultDevice (through chdir) using the application path provided in argv[0] by the loader (see https://github.com/ekeeke/Genesis-Plus-GX/issues/357 and https://github.com/Fledge68/WiiFlow_Lite/issues/254)

These changes improve the robustness of functions mkdir, link and rename against such edge case, similarly to what is already done for other syscall functions.