### PR TITLE
Enable building devkitARM on FreeBSD

### DIFF
--- a/build-devkit.sh
+++ b/build-devkit.sh
@@ -37,6 +37,18 @@ DKA64_RULES_VER=1.1.1
 OSXMIN=${OSXMIN:-10.9}
 
 #---------------------------------------------------------------------------------
+# find proper patch
+#---------------------------------------------------------------------------------
+if [ -z "$PATCH" -a -x "$(which gpatch)" ]; then PATCH=$(which gpatch); fi
+if [ -z "$PATCH" -a -x "$(which patch)" ]; then PATCH=$(which patch); fi
+if [ -z "$PATCH" ]; then
+  echo no patch found
+  exit 1
+fi
+echo use $PATCH as patch
+export PATCH
+
+#---------------------------------------------------------------------------------
 function extract_and_patch {
 #---------------------------------------------------------------------------------
 	if [ ! -f extracted-$1-$2 ]; then
@@ -46,7 +58,7 @@ function extract_and_patch {
 	fi
 	if [[ ! -f patched-$1-$2 && -f $patchdir/$1-$2.patch ]]; then
 		echo "patching $1-$2"
-		patch -p1 -d $1-$2 -i $patchdir/$1-$2.patch || { echo "Error patching $1"; exit 1; }
+		$PATCH -p1 -d $1-$2 -i $patchdir/$1-$2.patch || { echo "Error patching $1"; exit 1; }
 		touch patched-$1-$2
 	fi
 }

--- a/dka64/scripts/build-crtls.sh
+++ b/dka64/scripts/build-crtls.sh
@@ -12,4 +12,4 @@ cd $BUILDDIR
 
 tar -xvf $SRCDIR/devkita64-rules-$DKA64_RULES_VER.tar.gz
 cd devkita64-rules-$DKA64_RULES_VER
-make install
+$MAKE install

--- a/dkarm-eabi/scripts/build-crtls.sh
+++ b/dkarm-eabi/scripts/build-crtls.sh
@@ -13,7 +13,7 @@ cd $BUILDDIR
 
 tar -xvf $SRCDIR/devkitarm-rules-$DKARM_RULES_VER.tar.gz
 cd devkitarm-rules-$DKARM_RULES_VER
-make install
+$MAKE install
 
 #---------------------------------------------------------------------------------
 # Install and build the crt0 files
@@ -22,5 +22,5 @@ cd $BUILDDIR
 
 tar -xvf $SRCDIR/devkitarm-crtls-$DKARM_CRTLS_VER.tar.gz
 cd devkitarm-crtls-$DKARM_CRTLS_VER
-make install
+$MAKE install
 

--- a/dkppc/scripts/build-crtls.sh
+++ b/dkppc/scripts/build-crtls.sh
@@ -13,4 +13,4 @@ cd $BUILDDIR
 
 tar -xvf $SRCDIR/devkitppc-rules-$DKPPC_RULES_VER.tar.gz
 cd devkitppc-rules-$DKPPC_RULES_VER
-make install
+$MAKE install


### PR DESCRIPTION
When attempting to build devkitARM for FreeBSD, I ran into a few hiccups, all of which were resolved by using GNU versions make and patch.

There was already some logic to discover and use GNU Make, but not all build scripts were using the exported `$MAKE` variable. Commit [crtls: Use exported make](https://github.com/devkitPro/buildscripts/commit/024efd541c15104b9030a661ad69054189958975) ensures that the crtls build scripts make use of `$MAKE`.

I copied and modified the logic we had to discover GNU Make to discover and use GNU Patch. Anytime we want to apply patches, we now use the new variable `$PATCH`. BSD patch wasn't able to apply the patches correctly, as explained in the commit message. Commit [Prefer using GNU Patch](https://github.com/devkitPro/buildscripts/commit/805641d5569dab37841c029bb9ce381e6c28ce24) ensures that GNU Patch is used when available.

Together, with both these commits, I'm able to successfully build devkitARM r64 (though I had to first manually download GCC `gcc-14.1.0.tar.xz`, as this was 404 from the devkitpro servers for me last I tried). The command I used to build was: `EXTRA_GCC_PARAMS="--with-gmp=/usr/local --with-mpft=/usr/local --with-mpc=/usr/local" ./build-devkit.sh`. (Auto-discovery of my installed GMP didn't work, so I specified it manually.)