### PR TITLE
fix nullptr deref in devoptab_list

### DIFF
--- a/dka64/patches/newlib-4.5.0.20241231.patch
+++ b/dka64/patches/newlib-4.5.0.20241231.patch
@@ -7966,14 +7966,15 @@ index 000000000..5e81c5d42
 +#endif
 diff --git a/libgloss/libsysbase/iosupport.c b/libgloss/libsysbase/iosupport.c
 new file mode 100644
-index 000000000..71224902f
+index 000000000..021b1a6b6
 --- /dev/null
 +++ b/libgloss/libsysbase/iosupport.c
-@@ -0,0 +1,138 @@
+@@ -0,0 +1,145 @@
 +#include <stdlib.h>
 +#include <string.h>
 +#include <ctype.h>
 +#include <sys/iosupport.h>
++#include <assert.h>
 +
 +static int defaultDevice = -1;
 +
@@ -8025,13 +8026,19 @@ index 000000000..71224902f
 +};
 +
 +//---------------------------------------------------------------------------------
-+const devoptab_t *devoptab_list[STD_MAX] = {
++const devoptab_t *devoptab_list[] = {
 +//---------------------------------------------------------------------------------
 +	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
 +	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
 +	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
-+	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull
 +};
++static_assert(STD_MAX == sizeof(devoptab_list) / sizeof(devoptab_list[0]));
 +
 +//---------------------------------------------------------------------------------
 +int FindDevice(const char* name) {

--- a/dkarm-eabi/patches/newlib-4.5.0.20241231.patch
+++ b/dkarm-eabi/patches/newlib-4.5.0.20241231.patch
@@ -7966,14 +7966,15 @@ index 000000000..5e81c5d42
 +#endif
 diff --git a/libgloss/libsysbase/iosupport.c b/libgloss/libsysbase/iosupport.c
 new file mode 100644
-index 000000000..71224902f
+index 000000000..84d14d56f
 --- /dev/null
 +++ b/libgloss/libsysbase/iosupport.c
-@@ -0,0 +1,138 @@
+@@ -0,0 +1,145 @@
 +#include <stdlib.h>
 +#include <string.h>
 +#include <ctype.h>
 +#include <sys/iosupport.h>
++#include <assert.h>
 +
 +static int defaultDevice = -1;
 +
@@ -8030,8 +8031,14 @@ index 000000000..71224902f
 +	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
 +	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
 +	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
-+	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull
 +};
++static_assert(STD_MAX == sizeof(devoptab_list) / sizeof(devoptab_list[0]));
 +
 +//---------------------------------------------------------------------------------
 +int FindDevice(const char* name) {

--- a/dkppc/patches/newlib-4.5.0.20241231.patch
+++ b/dkppc/patches/newlib-4.5.0.20241231.patch
@@ -7916,14 +7916,15 @@ index 000000000..5e81c5d42
 +#endif
 diff --git a/libgloss/libsysbase/iosupport.c b/libgloss/libsysbase/iosupport.c
 new file mode 100644
-index 000000000..71224902f
+index 000000000..84d14d56f
 --- /dev/null
 +++ b/libgloss/libsysbase/iosupport.c
-@@ -0,0 +1,138 @@
+@@ -0,0 +1,145 @@
 +#include <stdlib.h>
 +#include <string.h>
 +#include <ctype.h>
 +#include <sys/iosupport.h>
++#include <assert.h>
 +
 +static int defaultDevice = -1;
 +
@@ -7980,8 +7981,14 @@ index 000000000..71224902f
 +	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
 +	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
 +	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
-+	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull, &dotab_stdnull,
++	&dotab_stdnull, &dotab_stdnull, &dotab_stdnull
 +};
++static_assert(STD_MAX == sizeof(devoptab_list) / sizeof(devoptab_list[0]));
 +
 +//---------------------------------------------------------------------------------
 +int FindDevice(const char* name) {


### PR DESCRIPTION
fixes devkitPro/newlib#35 

NOTE: i have not tried compile the changes. I am not sure if newlib is built with c11, if not then then it will fail due to the static assert. I can either remove it or create my own static assert.